### PR TITLE
Added LDADD = -lm to avoid linking references to libmath errors

### DIFF
--- a/01.w_Defects/Makefile.am
+++ b/01.w_Defects/Makefile.am
@@ -1,6 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CFLAGS = -pthread
 AM_LDFLAGS = -lm
+LDADD = -lm
 bin_PROGRAMS = 01_w_Defects
 01_w_Defects_SOURCES = \
 HeaderFile.h \

--- a/02.wo_Defects/Makefile.am
+++ b/02.wo_Defects/Makefile.am
@@ -1,6 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CFLAGS = -pthread
 AM_LDFLAGS = -lm
+LDADD = -lm
 bin_PROGRAMS = 02_wo_Defects
 02_wo_Defects_SOURCES = \
 bit_shift.c				lock_never_unlock.c \


### PR DESCRIPTION
I tried to compile on a Ubuntu 12.04 GCC 4.6.4, it complained about missing reference to libmath. LDADD[1] will tell autotools to add these variable AFTER the objects list.

Thanks for the benchmark!

[1] http://stackoverflow.com/questions/13610572/correcting-the-gcc-command-line-ordering-using-automake
